### PR TITLE
Update NOTES.txt and deployment.yaml

### DIFF
--- a/src/charts/iot-edge-connector/templates/NOTES.txt
+++ b/src/charts/iot-edge-connector/templates/NOTES.txt
@@ -2,4 +2,4 @@ The edge provider virtual kubelet is getting deployed on your cluster.
 
 To verify that edge provider virtual kubelet has started, run:
 
-  kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "edge-provider.fullname" . }}"
+kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "edge-provider.name" . }}" -l "release={{ .Release.Name }}"

--- a/src/charts/iot-edge-connector/templates/deployment.yaml
+++ b/src/charts/iot-edge-connector/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "edge-provider.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:


### PR DESCRIPTION
First issue:

In the NOTES.txt we get the instruction to run the following command to check our helm chart deployment

`kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "edge-provider.fullname" . }}"`

when executing the deployment via

`helm install -n hub0 .`

When running the command we get the message No resources found.

```
kubectl --namespace=default get pods -l app=hub0-iot-edge-connector

[21:51:23 azcdmdn@DANEUM:~$]
 > kubectl --namespace=default get pods -l app=hub0-iot-edge-connector
No resources found.
```

The solution would be to change the instructions to the following one in the NOTES.txt.

`kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "edge-provider.name" . }}"`

But this would force the second issue, where we then get all iot-edge-connector deployments targeting different Azure IoT Hubs.

```
kubectl --namespace=default get pods -l app=iot-edge-connector

[21:51:38 azcdmdn@DANEUM:~$]
 > kubectl --namespace=default get pods -l app=iot-edge-connector
NAME                                       READY   STATUS    RESTARTS   AGE
hub0-iot-edge-connector-6b594c6444-cbktp   2/2     Running   2          6h
hub1-iot-edge-connector-755f8c658b-nzhl9   2/2     Running   1          6h
```

The best option is to add also the release label here to the instructions.
 
`kubectl --namespace={{ .Release.Namespace }} get pods -l "app={{ template "edge-provider.name" . }}" -l "release={{ .Release.Name }}"`

```
kubectl --namespace=default get pods -l app=iot-edge-connector -l release=hub0

[21:52:41 azcdmdn@DANEUM:~$]
 > kubectl --namespace=default get pods -l app=iot-edge-connector -l release=hub0
NAME                                       READY   STATUS    RESTARTS   AGE
hub0-iot-edge-connector-6b594c6444-cbktp   2/2     Running   2          6h
```

Getting the approach to work we also need to implement changes to line 14 in the deployment.yaml, where we add the release label to avoid that all iot-edge-connector deployments will be given back in the instructions output of the helm command.